### PR TITLE
docs: update scrollIntoView() block parameter description in API docu…

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -46,9 +46,13 @@ scrollIntoView(scrollIntoViewOptions)
         - `instant`: scrolling should happen instantly in a single jump
         - `auto`: scroll behavior is determined by the computed value of {{cssxref("scroll-behavior")}}
     - `block` {{optional_inline}}
-      - : Defines vertical alignment.
-        One of `start`, `center`, `end`, or
-        `nearest`. Defaults to `start`.
+      - : Defines the vertical alignment of the element within the scrollable ancestor container. This option is a string and accepts one of the following values:
+        - `start`: Aligns the element's top edge with the top of the scrollable container, making the element appear at the start of the visible area vertically.
+        - `center`: Aligns the element vertically at the center of the scrollable container, positioning it in the middle of the visible area.
+        - `end`: Aligns the element's bottom edge with the bottom of the scrollable container, placing the element at the end of the visible area vertically.
+        - `nearest`: Scrolls the element to the nearest edge in the vertical direction. If the element is closer to the top edge of the scrollable container, it will align to the top; if it's closer to the bottom 
+          edge, it will align to the bottom. This minimizes the scrolling distance.
+        - Defaults to `start`.
     - `inline` {{optional_inline}}
       - : Defines horizontal alignment.
         One of `start`, `center`, `end`, or


### PR DESCRIPTION
…mentation

<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Updated the documentation for the `block` parameter in `scrollIntoView()` to clarify its possible values (`start`, `center`, `end`, `nearest`) and their effects on vertical alignment. This change improves understanding of the parameter by providing a detailed explanation similar to the existing `behavior` parameter description.

### Motivation

The original documentation lacked specific details on how the `block` parameter values affect element alignment within the scrollable ancestor. By expanding this section, we help developers better understand the use of `block`, especially in cases where precise element positioning is needed.

### Additional details

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

### Related issues and pull requests

Fixes #36679


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
